### PR TITLE
allow hspec 2.4

### DIFF
--- a/src/Test/Hspec/SmallCheck.hs
+++ b/src/Test/Hspec/SmallCheck.hs
@@ -21,7 +21,9 @@ instance Example (Property IO) where
           modifyIORef counter succ
           n <- readIORef counter
           reportProgress (n, 0)
-#if MIN_VERSION_hspec_core(2,2,0)
+#if MIN_VERSION_hspec_core(2,4,0)
+    maybe Success (Failure Nothing . Reason . ppFailure) <$> smallCheckWithHook (paramsSmallCheckDepth c) hook p
+#elif MIN_VERSION_hspec_core(2,2,0)
     maybe Success (Fail Nothing . ppFailure) <$> smallCheckWithHook (paramsSmallCheckDepth c) hook p
 #else
     maybe Success (Fail . ppFailure) <$> smallCheckWithHook (paramsSmallCheckDepth c) hook p

--- a/test/Test/Hspec/SmallCheckSpec.hs
+++ b/test/Test/Hspec/SmallCheckSpec.hs
@@ -22,14 +22,19 @@ spec = do
         evaluateExample (test True :: Property IO) `shouldReturn` H.Success
 
       it "returns Fail if property does not hold" $ do
-#if MIN_VERSION_hspec_core(2,2,0)
+#if MIN_VERSION_hspec_core(2,4,0)
+        evaluateExample (test False :: Property IO) `shouldReturn` H.Failure Nothing (H.Reason "condition is false")
+#elif MIN_VERSION_hspec_core(2,2,0)
         evaluateExample (test False :: Property IO) `shouldReturn` H.Fail Nothing "condition is false"
 #else
         evaluateExample (test False :: Property IO) `shouldReturn` H.Fail "condition is false"
 #endif
 
       it "shows what falsified it" $ do
-#if MIN_VERSION_hspec_core(2,2,0)
+
+#if MIN_VERSION_hspec_core(2,4,0)
+        evaluateExample (test (/= (2 :: Int)) :: Property IO) `shouldReturn` H.Failure Nothing (H.Reason "there exists 2 such that\n  condition is false")
+#elif MIN_VERSION_hspec_core(2,2,0)
         evaluateExample (test (/= (2 :: Int)) :: Property IO) `shouldReturn` H.Fail Nothing "there exists 2 such that\n  condition is false"
 #else
         evaluateExample (test (/= (2 :: Int)) :: Property IO) `shouldReturn` H.Fail "there exists 2 such that\n  condition is false"


### PR DESCRIPTION
hspec changed from `Fail (Maybe Location) String` to `Failure (Maybe Location) FailureReason` in version 2.4.0.

The changelog doesn't mention it but I think it's a bug, see https://github.com/hspec/hspec/issues/305